### PR TITLE
Return error message if requested word is not found

### DIFF
--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -28,11 +28,17 @@ class CurlHandler
     {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $req->getUrl());
+        curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $req->getHeader());
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $result = curl_exec($ch);
         $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
+
+        if ($status==404) {
+            return false;
+        }
+        
         $result = json_decode($result, true);
         return $result;
     }

--- a/src/SlackBot.php
+++ b/src/SlackBot.php
@@ -18,15 +18,20 @@ class SlackBot
         CurlHandler::sendMessage($slackReq);
     }
 
-    public static function getDefinition($url, $word)
+    public static function getDefinition($url, $wordText)
     {
-        $word = WordRequest::getDefinition($word);
-        $slackMessage = self::buildMessage($word);
-        $slackReq = new SlackRequest($url, json_encode($slackMessage->serialize()));
+        $word = WordRequest::getDefinition($wordText);
+        if ($word) {
+            $slackMessage = self::buildDefinitionMessage($word);
+            $slackReq = new SlackRequest($url, json_encode($slackMessage->serialize()));
+        } else {
+            $slackMessage = self::buildNotFoundMessage($wordText);
+            $slackReq = new SlackRequest($url, json_encode($slackMessage->serialize()));
+        }
         CurlHandler::sendMessage($slackReq);
     }
 
-    private static function buildMessage(Word $word)
+    private static function buildDefinitionMessage(Word $word)
     {
         $message = new SlackMessage();
         $message->setText("New Word");
@@ -38,6 +43,13 @@ class SlackBot
         $attachment[1]["text"] = $word->getDefintion();
         $attachment[1]["color"] = "#aba5ed";
         $message->setAttachment($attachment);
+        return $message;
+    }
+
+    private static function buildNotFoundMessage($word)
+    {
+        $message = new SlackMessage();
+        $message->setText("Sorry, Icouldn't find $word. :disappointed: Try checking your spelling.");
         return $message;
     }
 }

--- a/src/SlackBot.php
+++ b/src/SlackBot.php
@@ -49,7 +49,7 @@ class SlackBot
     private static function buildNotFoundMessage($word)
     {
         $message = new SlackMessage();
-        $message->setText("Sorry, Icouldn't find $word. :disappointed: Try checking your spelling.");
+        $message->setText("Sorry, I couldn't find $word. :disappointed: Try checking your spelling.");
         return $message;
     }
 }

--- a/src/WordRequest.php
+++ b/src/WordRequest.php
@@ -66,7 +66,10 @@ class WordRequest
         $wordReq = new WordRequest($url, $headers);
 
         $result = CurlHandler::callAPI($wordReq);
-        return new Word($result["word"], $result["definitions"][0]["definition"]);
+        if ($result) {
+            return new Word($result["word"], $result["definitions"][0]["definition"]);
+        } else {
+            return false;
+        }
     }
-
 }


### PR DESCRIPTION
If the word wasn't found, the bot responds: "Sorry, I couldn't find $word. :disappointed: Try checking your spelling."